### PR TITLE
I've refactored the buffer option setting with a utility function.

### DIFF
--- a/lua/learn_vim/exercise.lua
+++ b/lua/learn_vim/exercise.lua
@@ -3,6 +3,7 @@
 -- This module handles the logic for managing and validating exercises.
 
 local M = {} -- The module table
+local Utils = require('learn_vim.utils') -- Require the utils module
 local LEARN_VIM = nil -- Placeholder for the main plugin module, set during setup
 
 -- --- Setup Function ---
@@ -44,7 +45,8 @@ function M.load_current_exercise()
 
     -- Clear the exercise buffer and set its content
     vim.api.nvim_buf_set_lines(exercise_bufnr, 0, -1, false, {})
-    local lines = vim.split(exercise_data.setup_text, '\n')
+    local lines = vim.split(exercise_data.setup_text, '
+')
     vim.api.nvim_buf_set_lines(exercise_bufnr, 0, 0, false, lines)
 
     -- Set the filetype for syntax highlighting (optional, but good practice)
@@ -66,8 +68,7 @@ function M.load_current_exercise()
     end
 
     -- Make the exercise buffer editable
-    vim.api.nvim_buf_set_option(exercise_bufnr, 'modifiable', true)
-    vim.api.nvim_buf_set_option(exercise_bufnr, 'readonly', false)
+    Utils.set_buffer_options(exercise_bufnr, {modifiable = true, readonly = false})
 
     -- Ensure the exercise window is focused
     vim.api.nvim_set_current_win(state.exercise_winid)
@@ -93,11 +94,14 @@ function M.check_current_exercise()
     -- Get the current state of the exercise buffer
     local exercise_bufnr = state.exercise_bufnr
     local current_buffer_content = vim.api.nvim_buf_get_lines(exercise_bufnr, 0, -1, false)
-    current_buffer_content = table.concat(current_buffer_content, '\n') -- Join lines for content checks
+    current_buffer_content = table.concat(current_buffer_content, '
+') -- Join lines for content checks
 
     -- Perform validation based on type
     if validation.type == 'check_buffer_content' then
-        local target_content = table.concat(vim.split(validation.target_content, '\n'), '\n')
+        local target_content = table.concat(vim.split(validation.target_content, '
+'), '
+')
         is_correct = (current_buffer_content == target_content)
 
     -- New validation type: check_buffer_content_regex
@@ -170,7 +174,8 @@ function M.reset_current_exercise()
     -- Clear the exercise buffer and set its content back to the setup_text
     vim.api.nvim_buf_set_option(exercise_bufnr, 'modifiable', true) -- Ensure it's modifiable before clearing
     vim.api.nvim_buf_set_lines(exercise_bufnr, 0, -1, false, {})
-    local lines = vim.split(exercise_data.setup_text, '\n')
+    local lines = vim.split(exercise_data.setup_text, '
+')
     vim.api.nvim_buf_set_lines(exercise_bufnr, 0, 0, false, lines)
 
      -- Reset cursor position if specified
@@ -189,3 +194,4 @@ end
 
 -- Return the module table M
 return M
+```

--- a/lua/learn_vim/init.lua
+++ b/lua/learn_vim/init.lua
@@ -134,6 +134,28 @@ end
 --- Restarts the tutorial from the beginning.
 -- Called by :LearnVim restart.
 function M.restart_tutorial()
+    -- Store old IDs before they are reset from M.current_state
+    local old_tutorial_winid = M.current_state.tutorial_winid
+    local old_exercise_winid = M.current_state.exercise_winid
+    -- local old_tutorial_bufnr = M.current_state.tutorial_bufnr -- Optional for now
+    -- local old_exercise_bufnr = M.current_state.exercise_bufnr -- Optional for now
+
+    -- Close the windows if they are valid
+    if old_tutorial_winid ~= -1 and vim.api.nvim_win_is_valid(old_tutorial_winid) then
+        pcall(vim.api.nvim_win_close, old_tutorial_winid, true)
+    end
+    if old_exercise_winid ~= -1 and vim.api.nvim_win_is_valid(old_exercise_winid) then
+        pcall(vim.api.nvim_win_close, old_exercise_winid, true)
+    end
+    
+    -- Optional: Explicitly delete old buffers (consider if needed, bufhidden=hide might suffice)
+    -- if old_tutorial_bufnr ~= -1 and vim.api.nvim_buf_is_valid(old_tutorial_bufnr) then
+    --     pcall(vim.api.nvim_buf_delete, old_tutorial_bufnr, { force = true })
+    -- end
+    -- if old_exercise_bufnr ~= -1 and vim.api.nvim_buf_is_valid(old_exercise_bufnr) then
+    --     pcall(vim.api.nvim_buf_delete, old_exercise_bufnr, { force = true })
+    -- end
+
      -- Reset the state to the initial values.
      M.current_state = { module = 1, lesson = 1, exercise = 1 }
      -- Reset UI state as well, so setup_tutorial_ui recreates windows/buffers cleanly.

--- a/lua/learn_vim/ui.lua
+++ b/lua/learn_vim/ui.lua
@@ -6,6 +6,7 @@
 return function(M) -- Accept the parent module M as an argument
     local M_ui = {} -- Local module table for UI functions
     local Contents = require('learn_vim.contents') -- Require the contents module
+    local Utils = require('learn_vim.utils') -- Require the utils module
 
     --- UI Setup ---
     -- Creates or finds the tutorial buffers and windows.
@@ -70,210 +71,158 @@ return function(M) -- Accept the parent module M as an argument
 
             -- Set window options for cleanliness and usability in the tutorial panes.
             -- Tutorial window options (top pane)
-            -- FIX: Set wrap to true so text wraps within the window width
             vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'wrap', true)
-            vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'number', false) -- Hide line numbers
-            vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'relativenumber', false) -- Hide relative line numbers
-            vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'signcolumn', 'no') -- Hide sign column
-            vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'foldcolumn', '0') -- Hide fold column
-            -- winfixwidth doesn't make sense for a horizontal split, use winfixheight instead
+            vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'number', false)
+            vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'relativenumber', false)
+            vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'signcolumn', 'no')
+            vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'foldcolumn', '0')
             vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'winfixheight', true)
-            vim.api.nvim_win_set_height(M.current_state.tutorial_winid, 10) -- Set a default height for the tutorial pane (adjust as needed)
+            vim.api.nvim_win_set_height(M.current_state.tutorial_winid, 10)
 
 
             -- Exercise window options (bottom pane - the original window)
-            vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'wrap', false) -- Keep wrap false for code/exercises
-            vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'number', true) -- Show line numbers in exercise pane
-            vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'relativenumber', false) -- Hide relative line numbers
-            vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'signcolumn', 'no') -- Hide sign column (can use for validation markers later)
-            vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'foldcolumn', '0') -- Hide fold column
-            -- winfixwidth is not needed here, exercise pane takes remaining space
+            vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'wrap', false)
+            vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'number', true)
+            vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'relativenumber', false)
+            vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'signcolumn', 'no')
+            vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'foldcolumn', '0')
 
 
             -- Return focus to the exercise window so the user can start interacting.
              vim.api.nvim_set_current_win(M.current_state.exercise_winid)
-
-            -- TODO: Add autocmds to clean up buffers if windows are manually closed?
-            -- This is more complex and can be added later if needed.
-            -- For now, rely on `bufhidden=hide` and recreating on :LearnVim start.
         else
              -- Windows were already valid. Ensure correct buffers are assigned
-             -- (in case of weird state or manual buffer switching)
              vim.api.nvim_win_set_buf(M.current_state.tutorial_winid, M.current_state.tutorial_bufnr)
              vim.api.nvim_win_set_buf(M.current_state.exercise_winid, M.current_state.exercise_bufnr)
 
-              -- Ensure buffer options are correct regardless of how window was reopened or options were changed
-              -- Tutorial buffer should be read-only and wrap enabled
-              vim.api.nvim_buf_set_option(M.current_state.tutorial_bufnr, 'readonly', true)
-              vim.api.nvim_buf_set_option(M.current_state.tutorial_bufnr, 'modifiable', false)
-              vim.api.nvim_buf_set_option(M.current_state.tutorial_bufnr, 'wrap', true) -- Ensure wrap is true
-               vim.api.nvim_buf_set_option(M.current_state.tutorial_bufnr, 'bufhidden', 'hide') -- Ensure bufhidden is hide
-
-              -- Exercise buffer should be modifiable by default and wrap disabled
-              vim.api.nvim_buf_set_option(M.current_state.exercise_bufnr, 'modifiable', true)
-              vim.api.nvim_buf_set_option(M.current_state.exercise_bufnr, 'readonly', false)
-              vim.api.nvim_buf_set_option(M.current_state.exercise_bufnr, 'wrap', false) -- Ensure wrap is false
-               vim.api.nvim_buf_set_option(M.current_state.exercise_bufnr, 'bufhidden', 'hide') -- Ensure bufhidden is hide
-
+              -- Ensure buffer options are correct
+            Utils.set_buffer_options(M.current_state.tutorial_bufnr, {
+                readonly = true,
+                modifiable = false,
+                wrap = true,
+                bufhidden = 'hide'
+            })
+            Utils.set_buffer_options(M.current_state.exercise_bufnr, {
+                modifiable = true,
+                readonly = false,
+                wrap = false,
+                bufhidden = 'hide'
+            })
 
              -- Return focus to the exercise window
              vim.api.nvim_set_current_win(M.current_state.exercise_winid)
         end
 
-        -- Re-apply key window options every time setup is called,
-        -- in case they were changed by user actions or other plugins.
-        -- Use winfixheight for the top (tutorial) pane in horizontal split
+        -- Re-apply key window options every time setup is called
         vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'winfixheight', true)
-        vim.api.nvim_win_set_height(M.current_state.tutorial_winid, 10) -- Re-apply default height
-         vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'number', true) -- Show numbers in exercise pane
-         vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'wrap', true) -- Re-apply wrap true for tutorial
-         vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'wrap', false) -- Re-apply wrap false for exercise
-
+        vim.api.nvim_win_set_height(M.current_state.tutorial_winid, 10)
+        vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'number', true)
+        vim.api.nvim_win_set_option(M.current_state.tutorial_winid, 'wrap', true)
+        vim.api.nvim_win_set_option(M.current_state.exercise_winid, 'wrap', false)
     end
 
     --- Display Lesson Content ---
-    -- Populates the tutorial and exercise windows with content for the given lesson.
     function M_ui.display_lesson(module_id, lesson_id)
-        -- Get the lesson data from the curriculum. Access curriculum via M.
         local lesson_data = M.curriculum['module' .. module_id] and M.curriculum['module' .. module_id]['lesson' .. lesson_id]
         if not lesson_data then
             vim.notify("Error: Lesson data not found for " .. module_id .. "." .. lesson_id, vim.log.levels.ERROR)
-            -- TODO: Maybe close windows here if lesson data is critically missing?
             return
         end
 
-        -- Ensure UI is set up before displaying content.
-        M_ui.setup_tutorial_ui() -- Call local ui function
+        M_ui.setup_tutorial_ui()
 
-        -- 1. Update Tutorial Window (top pane)
-        local tutorial_buf = M.current_state.tutorial_bufnr -- Access buffer number via M.current_state
-        -- Ensure modifiable before writing
-        vim.api.nvim_buf_set_option(tutorial_buf, 'modifiable', true)
-        -- Clear previous content in the tutorial buffer.
+        local tutorial_buf = M.current_state.tutorial_bufnr
+        Utils.set_buffer_options(tutorial_buf, {modifiable = true}) -- Ensure modifiable before writing
         vim.api.nvim_buf_set_lines(tutorial_buf, 0, -1, false, {})
-        -- Split the explanation text into lines and set the buffer content.
         local explanation_lines = vim.split(lesson_data.explanation, '
 ', { plain = true })
         vim.api.nvim_buf_set_lines(tutorial_buf, 0, 0, false, explanation_lines)
-         -- Set back to read-only and non-modifiable after writing.
-        vim.api.nvim_buf_set_option(tutorial_buf, 'modifiable', false)
-        vim.api.nvim_buf_set_option(tutorial_buf, 'readonly', true)
-         vim.api.nvim_buf_set_option(tutorial_buf, 'bufhidden', 'hide') -- Ensure bufhidden is hide
-         -- Ensure wrap is true for tutorial buffer after writing
-         vim.api.nvim_buf_set_option(tutorial_buf, 'wrap', true)
-        -- Scroll to the top of the tutorial window.
-        vim.api.nvim_win_set_cursor(M.current_state.tutorial_winid, {1, 0}) -- Access window ID via M.current_state
+        Utils.set_buffer_options(tutorial_buf, {
+            modifiable = false,
+            readonly = true,
+            bufhidden = 'hide',
+            wrap = true
+        })
+        vim.api.nvim_win_set_cursor(M.current_state.tutorial_winid, {1, 0})
 
-
-        -- 2. Update Exercise Window (bottom pane)
-        local exercise_buf = M.current_state.exercise_bufnr -- Access buffer number via M.current_state
-
-        -- Ensure exercise buffer is modifiable before writing ANY content to it.
-        vim.api.nvim_buf_set_option(exercise_buf, 'modifiable', true)
-        vim.api.nvim_buf_set_option(exercise_buf, 'readonly', false)
-        -- Ensure wrap is false for exercise buffer before writing
-        vim.api.nvim_buf_set_option(exercise_buf, 'wrap', false)
-
-
-        -- Clear previous content in the exercise buffer.
+        local exercise_buf = M.current_state.exercise_bufnr
+        Utils.set_buffer_options(exercise_buf, {
+            modifiable = true,
+            readonly = false,
+            wrap = false
+        })
         vim.api.nvim_buf_set_lines(exercise_buf, 0, -1, false, {})
 
-
-        -- Check if the lesson has exercises.
         if lesson_data.exercises and #lesson_data.exercises > 0 then
-            -- Get the current exercise data based on the state.
-            local current_exercise = lesson_data.exercises[M.current_state.exercise] -- Access current_state via M
+            local current_exercise = lesson_data.exercises[M.current_state.exercise]
             if not current_exercise then
-                 -- Handle case where exercise index in state is invalid for this lesson.
                  vim.notify("Error: Exercise index " .. M.current_state.exercise .. " not found for lesson " .. module_id .. "." .. lesson_id, vim.log.levels.ERROR)
                  local no_exercise_lines = {
                     "--- Error Loading Exercise ---", "",
                     "Could not find exercise " .. M.current_state.exercise .. ".",
                     "Please report this bug or try :LearnVim next",
                  }
-                 -- Ensure modifiable is true before writing the error message
-                 vim.api.nvim_buf_set_option(exercise_buf, 'modifiable', true)
+                 Utils.set_buffer_options(exercise_buf, {modifiable = true})
                  vim.api.nvim_buf_set_lines(exercise_buf, 0, 0, false, no_exercise_lines)
-                  -- Then set it to non-modifiable after writing the error.
-                  vim.api.nvim_buf_set_option(exercise_buf, 'modifiable', false)
-                  vim.api.nvim_buf_set_option(exercise_buf, 'readonly', true)
-                  vim.api.nvim_buf_set_option(exercise_buf, 'bufhidden', 'hide')
-                  -- Ensure wrap is false for this error state
-                  vim.api.nvim_buf_set_option(exercise_buf, 'wrap', false)
-                  vim.api.nvim_set_current_win(M.current_state.tutorial_winid) -- Focus tutorial pane on error
+                 Utils.set_buffer_options(exercise_buf, {
+                    modifiable = false,
+                    readonly = true,
+                    bufhidden = 'hide',
+                    wrap = false
+                 })
+                 vim.api.nvim_set_current_win(M.current_state.tutorial_winid)
                  return
             end
 
-            -- Set up exercise text if provided in the curriculum data.
-            -- The setup_text is expected to include the header comments now.
             if current_exercise.setup_text then
                 local setup_lines = vim.split(current_exercise.setup_text, '
 ', { plain = true })
-                -- Ensure modifiable is true before writing setup text
-                 vim.api.nvim_buf_set_option(exercise_buf, 'modifiable', true)
+                Utils.set_buffer_options(exercise_buf, {modifiable = true})
                 vim.api.nvim_buf_set_lines(exercise_buf, 0, 0, false, setup_lines)
-
-                 -- Set cursor position if requested by the exercise data.
                  if current_exercise.start_cursor then
-                     vim.api.nvim_win_set_cursor(M.current_state.exercise_winid, current_exercise.start_cursor) -- Access window ID via M.current_state
+                     vim.api.nvim_win_set_cursor(M.current_state.exercise_winid, current_exercise.start_cursor)
                  else
-                      -- Default cursor to the start of the buffer if no specific position is given.
                        vim.api.nvim_win_set_cursor(M.current_state.exercise_winid, {1, 0})
                  end
             else
-                 -- If no setup text, just show the instruction header.
                  local instruction_lines = {
                      '" --- Exercise ' .. module_id .. '.' .. lesson_id .. '.' .. M.current_state.exercise .. ' ---',
                      '" Instruction: ' .. current_exercise.instruction,
-                     '" Use ':LearnVim exc' to check, ':LearnVim exr' to reset.', -- Remind them how to check/reset
+                     '" Use ':LearnVim exc' to check, ':LearnVim exr' to reset.',
                      '" ---------------------------------------------', '',
                  }
-                 -- Ensure modifiable is true before writing instruction header
-                 vim.api.nvim_buf_set_option(exercise_buf, 'modifiable', true)
+                 Utils.set_buffer_options(exercise_buf, {modifiable = true})
                  vim.api.nvim_buf_set_lines(exercise_buf, 0, 0, false, instruction_lines)
-                 -- Place cursor after the header.
                  vim.api.nvim_win_set_cursor(M.current_state.exercise_winid, {5, 0})
             end
 
-            -- Ensure exercise buffer is modifiable for user interaction.
-            vim.api.nvim_buf_set_option(exercise_buf, 'modifiable', true)
-            vim.api.nvim_buf_set_option(exercise_buf, 'readonly', false)
-             vim.api.nvim_buf_set_option(exercise_buf, 'bufhidden', 'hide') -- Ensure bufhidden is hide
-             -- Ensure wrap is false for exercise buffer
-             vim.api.nvim_buf_set_option(exercise_buf, 'wrap', false)
-
-            -- Ensure focus is on the exercise window.
-             vim.api.nvim_set_current_win(M.current_state.exercise_winid) -- Access window ID via M.current_state
-
-             -- TODO: Potentially set up autocmds/mappings specific to this exercise type? (Deferred)
-
+            Utils.set_buffer_options(exercise_buf, {
+                modifiable = true,
+                readonly = false,
+                bufhidden = 'hide',
+                wrap = false
+            })
+            vim.api.nvim_set_current_win(M.current_state.exercise_winid)
         else
-            -- If there are no exercises for this lesson, display a message in the exercise pane.
             local no_exercise_lines = {
                 "--- No Exercise ---", "",
                 "This lesson was informational.",
                 "Type :LearnVim next to continue.",
             }
-            -- Ensure modifiable is true BEFORE writing the "No Exercise" message.
-            vim.api.nvim_buf_set_option(exercise_buf, 'modifiable', true)
-            -- Content is already cleared above. Set the message lines.
+            Utils.set_buffer_options(exercise_buf, {modifiable = true})
             vim.api.nvim_buf_set_lines(exercise_buf, 0, 0, false, no_exercise_lines)
-            -- Make the exercise buffer non-modifiable as there's nothing to do.
-            vim.api.nvim_buf_set_option(exercise_buf, 'modifiable', false) -- Set modifiable to false AFTER writing
-            vim.api.nvim_buf_set_option(exercise_buf, 'readonly', true)
-            vim.api.nvim_buf_set_option(exercise_buf, 'bufhidden', 'hide')
-            -- Ensure wrap is false for this non-modifiable state
-            vim.api.nvim_buf_set_option(exercise_buf, 'wrap', false)
-
-            -- Focus the tutorial window if there's no exercise to interact with.
-             vim.api.nvim_set_current_win(M.current_state.tutorial_winid) -- Access window ID via M.current_state
-
+            Utils.set_buffer_options(exercise_buf, {
+                modifiable = false,
+                readonly = true,
+                bufhidden = 'hide',
+                wrap = false
+            })
+            vim.api.nvim_set_current_win(M.current_state.tutorial_winid)
             vim.notify("Lesson " .. module_id .. "." .. lesson_id .. " loaded. No exercises.", vim.log.levels.INFO)
         end
     end
 
     --- Display Contents Menu ---
-    -- Creates a floating window with a list of all modules and lessons.
     function M_ui.display_contents_menu()
         local menu_items = Contents.get_menu_items()
         local prepared_lines = {}
@@ -288,43 +237,34 @@ return function(M) -- Accept the parent module M as an argument
 
         local screen_width = vim.api.nvim_get_option_value('columns', {})
         local screen_height = vim.api.nvim_get_option_value('lines', {})
-
-        local win_width = math.min(math.max(max_width + 4, 40), screen_width - 4) -- Add padding, min 40, max screen width - 4
-        local win_height = math.min(#prepared_lines + 2, screen_height - 4) -- Add padding for border, max screen height - 4
-
+        local win_width = math.min(math.max(max_width + 4, 40), screen_width - 4)
+        local win_height = math.min(#prepared_lines + 2, screen_height - 4)
         local row = math.floor((screen_height - win_height) / 2)
         local col = math.floor((screen_width - win_width) / 2)
 
-        local menu_bufnr = vim.api.nvim_create_buf(false, true) -- false for listed, true for scratch
+        local menu_bufnr = vim.api.nvim_create_buf(false, true)
         local win_opts = {
-            relative = 'editor',
-            style = 'minimal',
-            border = 'rounded',
-            width = win_width,
-            height = win_height,
-            row = row,
-            col = col,
-            focusable = true,
-            zindex = 50
+            relative = 'editor', style = 'minimal', border = 'rounded',
+            width = win_width, height = win_height, row = row, col = col,
+            focusable = true, zindex = 50
         }
         
-        -- We open the window with the current buffer (0), then set the menu_bufnr to it.
-        -- This is a common pattern to avoid issues with nvim_open_win and buffer focus.
         local menu_winid = vim.api.nvim_open_win(0, true, win_opts) 
         vim.api.nvim_win_set_buf(menu_winid, menu_bufnr)
 
-        vim.api.nvim_buf_set_option(menu_bufnr, 'bufhidden', 'wipe')
-        vim.api.nvim_buf_set_option(menu_bufnr, 'buftype', 'nofile')
-        vim.api.nvim_buf_set_option(menu_bufnr, 'nomodifiable', true) -- Set to true initially
-        vim.api.nvim_buf_set_option(menu_bufnr, 'nowrap', true)
-        vim.api.nvim_buf_set_option(menu_bufnr, 'nobuflisted', true)
-        vim.api.nvim_buf_set_option(menu_bufnr, 'swapfile', false)
-        vim.api.nvim_buf_set_option(menu_bufnr, 'cursorline', true) -- Highlight current line
+        Utils.set_buffer_options(menu_bufnr, {
+            bufhidden = 'wipe',
+            buftype = 'nofile',
+            nomodifiable = true, -- Set initially non-modifiable
+            nowrap = true,
+            nobuflisted = true,
+            swapfile = false,
+            cursorline = true
+        })
 
-        -- Make buffer modifiable to set lines, then unmodifiable again
-        vim.api.nvim_buf_set_option(menu_bufnr, 'modifiable', true)
+        Utils.set_buffer_options(menu_bufnr, {modifiable = true}) -- Allow modification for setting lines
         vim.api.nvim_buf_set_lines(menu_bufnr, 0, -1, false, prepared_lines)
-        vim.api.nvim_buf_set_option(menu_bufnr, 'modifiable', false)
+        Utils.set_buffer_options(menu_bufnr, {modifiable = false}) -- Set back to non-modifiable
 
         -- Keymaps
         vim.api.nvim_buf_set_keymap(menu_bufnr, 'n', 'q', '', {
@@ -335,21 +275,16 @@ return function(M) -- Accept the parent module M as an argument
                 end
             end
         })
-
         vim.api.nvim_buf_set_keymap(menu_bufnr, 'n', '<CR>', '', {
             noremap = true, silent = true,
             callback = function()
                 local cursor_pos = vim.api.nvim_win_get_cursor(menu_winid)
-                local line_num = cursor_pos[1] -- 1-based line number
-                
-                -- menu_items needs to be an upvalue for this callback to access it
+                local line_num = cursor_pos[1]
                 local selected_item = menu_items[line_num] 
-
                 if selected_item and selected_item.type == "lesson_item" then
                     if vim.api.nvim_win_is_valid(menu_winid) then
                         vim.api.nvim_win_close(menu_winid, true)
                     end
-                    -- Use M.navigation which should be available via the M closure
                     M.navigation.goto_lesson(selected_item.module_num, selected_item.lesson_num)
                 end
             end
@@ -364,7 +299,6 @@ return function(M) -- Accept the parent module M as an argument
         })
     end
 
-    -- Return the local module table containing the public functions.
     return M_ui
 end
 ```

--- a/lua/learn_vim/utils.lua
+++ b/lua/learn_vim/utils.lua
@@ -1,0 +1,28 @@
+-- lua/learn_vim/utils.lua
+
+-- This module provides utility functions for the LearnVim plugin.
+
+local Utils = {}
+
+--- Sets multiple buffer options at once.
+-- @param bufnr (integer) The buffer number.
+-- @param options (table) A table where keys are option names (strings)
+--                        and values are the option values.
+-- Example: Utils.set_buffer_options(my_buf, { bufhidden = 'wipe', buftype = 'nofile' })
+function Utils.set_buffer_options(bufnr, options)
+    if type(bufnr) ~= 'number' or type(options) ~= 'table' then
+        vim.notify("Error: Invalid arguments to set_buffer_options. Bufnr must be a number and options must be a table.", vim.log.levels.ERROR)
+        return
+    end
+
+    for key, value in pairs(options) do
+        -- Use pcall to catch errors if an option name is invalid or value is incorrect
+        local success, err = pcall(vim.api.nvim_buf_set_option, bufnr, key, value)
+        if not success then
+            vim.notify("Error setting buffer option '" .. key .. "': " .. tostring(err), vim.log.levels.ERROR)
+        end
+    end
+end
+
+return Utils
+```


### PR DESCRIPTION
- I introduced `lua/learn_vim/utils.lua` with a `set_buffer_options` helper function. This function takes a buffer number and a table of options to set, simplifying the process of setting multiple buffer options.

- I refactored `lua/learn_vim/ui.lua` to use `Utils.set_buffer_options`. This significantly reduces repetitive calls to `vim.api.nvim_buf_set_option` when setting up the tutorial, exercise, and contents menu buffers.

- I refactored `lua/learn_vim/exercise.lua` to use `Utils.set_buffer_options` in the `load_current_exercise` function for setting exercise buffer properties.