### PR TITLE
Fix E95 error on :LearnVim restart by deleting old buffers

### DIFF
--- a/lua/learn_vim/init.lua
+++ b/lua/learn_vim/init.lua
@@ -137,8 +137,8 @@ function M.restart_tutorial()
     -- Store old IDs before they are reset from M.current_state
     local old_tutorial_winid = M.current_state.tutorial_winid
     local old_exercise_winid = M.current_state.exercise_winid
-    -- local old_tutorial_bufnr = M.current_state.tutorial_bufnr -- Optional for now
-    -- local old_exercise_bufnr = M.current_state.exercise_bufnr -- Optional for now
+    local old_tutorial_bufnr = M.current_state.tutorial_bufnr
+    local old_exercise_bufnr = M.current_state.exercise_bufnr
 
     -- Close the windows if they are valid
     if old_tutorial_winid ~= -1 and vim.api.nvim_win_is_valid(old_tutorial_winid) then
@@ -148,13 +148,13 @@ function M.restart_tutorial()
         pcall(vim.api.nvim_win_close, old_exercise_winid, true)
     end
     
-    -- Optional: Explicitly delete old buffers (consider if needed, bufhidden=hide might suffice)
-    -- if old_tutorial_bufnr ~= -1 and vim.api.nvim_buf_is_valid(old_tutorial_bufnr) then
-    --     pcall(vim.api.nvim_buf_delete, old_tutorial_bufnr, { force = true })
-    -- end
-    -- if old_exercise_bufnr ~= -1 and vim.api.nvim_buf_is_valid(old_exercise_bufnr) then
-    --     pcall(vim.api.nvim_buf_delete, old_exercise_bufnr, { force = true })
-    -- end
+    -- Explicitly delete old buffers
+    if old_tutorial_bufnr ~= -1 and vim.api.nvim_buf_is_valid(old_tutorial_bufnr) then
+        pcall(vim.api.nvim_buf_delete, old_tutorial_bufnr, { force = true })
+    end
+    if old_exercise_bufnr ~= -1 and vim.api.nvim_buf_is_valid(old_exercise_bufnr) then
+        pcall(vim.api.nvim_buf_delete, old_exercise_bufnr, { force = true })
+    end
 
      -- Reset the state to the initial values.
      M.current_state = { module = 1, lesson = 1, exercise = 1 }


### PR DESCRIPTION
The `:LearnVim restart` command previously caused an "E95: Buffer with this name already exists" error. This was because old tutorial/exercise buffers were not being fully deleted before new ones with the same names were created.

This commit fixes the issue by:
1.  In `lua/learn_vim/init.lua`'s `M.restart_tutorial` function:
    - Ensuring old tutorial and exercise window IDs are captured.
    - Explicitly closing these windows if they are valid.
    - **Crucially, explicitly deleting the old tutorial and exercise buffers using `vim.api.nvim_buf_delete(bufnr, {force = true})` after their windows are closed and before their IDs in the state are reset to -1.**
2.  Verified that `lua/learn_vim/ui.lua` correctly creates new unnamed scratch buffers via `vim.api.nvim_create_buf()` when buffer IDs in the state are invalid, before subsequently naming these new buffers. This complements the explicit deletion.

This ensures a clean slate for buffer creation during restart, preventing the name collision.