### PR TITLE
Fix: Correct target_cursor in check_cursor_position validations

### DIFF
--- a/lua/learn_vim/modules/module3.lua
+++ b/lua/learn_vim/modules/module3.lua
@@ -37,7 +37,7 @@ Use `:LearnVim exc` to check when you think you've completed the task!
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson1_exercise2_setup.txt"),
                 start_cursor = {5, 15}, -- Start on 'p' of 'pluck'
-                validation = { type = 'check_cursor_position', target_cursor = {5, 21} }, -- Target on 'y' of 'ivy'
+                validation = { type = 'check_cursor_position', target_cursor = {5, 23} }, -- Target on 'y' of 'ivy'
                 feedback = "Correct! 'e' moves to the end of the word.",
             },
              {
@@ -130,7 +130,7 @@ Let's practice these precise line movements. Use `:LearnVim exc` after each step
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson3_exercise4_setup.txt"),
                 start_cursor = {5, 0}, -- Start at the beginning
-                validation = { type = 'check_cursor_position', target_cursor = {5, 16} }, -- Target is the last character (the '.')
+                validation = { type = 'check_cursor_position', target_cursor = {5, 15} }, -- Target is the last character (the '.')
                 feedback = "Correct! '$' goes to the end of the line.",
             },
         },
@@ -174,15 +174,15 @@ Let's practice using counts with vertical and horizontal movements. Use `:LearnV
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson4_exercise3_setup.txt"),
                 start_cursor = {5, 12}, -- Start on 'O' of "One"
-                validation = { type = 'check_cursor_position', target_cursor = {5, 34} }, -- Target is the start of "six" (5 words after "One")
+                validation = { type = 'check_cursor_position', target_cursor = {5, 36} }, -- Target is the start of "six"
                 feedback = "Great! You jumped forward multiple words.",
             },
              {
                 instruction = "Using a numerical prefix with `b`, move backward exactly 3 words from the starting position. Then type `:LearnVim exc` to check.",
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson4_exercise4_setup.txt"),
-                start_cursor = {5, 38}, -- Start on 'S' of "Start"
-                validation = { type = 'check_cursor_position', target_cursor = {5, 23} }, -- Target is the start of "four" (3 words before "Start")
+                start_cursor = {5, 35}, -- Start on 'S' of "Start"
+                validation = { type = 'check_cursor_position', target_cursor = {5, 19} }, -- Target is the start of "five" (3 words before "Start")
                 feedback = "Excellent! You jumped backward multiple words.",
             },
         },

--- a/lua/learn_vim/modules/module7.lua
+++ b/lua/learn_vim/modules/module7.lua
@@ -32,7 +32,7 @@ Let's practice finding characters on a line. Use `:LearnVim exc` to check and `:
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module7_lesson1_exercise1_setup.txt"),
                 start_cursor = {5, 0}, -- Start at the beginning of the line
-                validation = { type = 'check_cursor_position', target_cursor = {5, 7} }, -- Target is the first 'a' in 'wizards'
+                validation = { type = 'check_cursor_position', target_cursor = {5, 10} }, -- Target is the first 'a' in 'wizards'
                 feedback = "You found the character!",
             },
              {
@@ -40,7 +40,7 @@ Let's practice finding characters on a line. Use `:LearnVim exc` to check and `:
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module7_lesson1_exercise2_setup.txt"),
                 start_cursor = {5, 0}, -- Start at the beginning
-                validation = { type = 'check_cursor_position', target_cursor = {5, 23} }, -- Target is the space before 'f' in 'from'
+                validation = { type = 'check_cursor_position', target_cursor = {5, 24} }, -- Target is the space before 'f' in 'from'
                 feedback = "You jumped just before the character!",
             },
              {
@@ -48,7 +48,7 @@ Let's practice finding characters on a line. Use `:LearnVim exc` to check and `:
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module7_lesson1_exercise3_setup.txt"),
                 start_cursor = {5, 0}, -- Start at the beginning
-                validation = { type = 'check_cursor_position', target_cursor = {5, 20} }, -- Target is the 'i' in 'ivy'
+                validation = { type = 'check_cursor_position', target_cursor = {5, 8} }, -- Target is the 'i' in 'wizards' (second 'i')
                 feedback = "You repeated the find forward!",
             },
              {
@@ -56,7 +56,7 @@ Let's practice finding characters on a line. Use `:LearnVim exc` to check and `:
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module7_lesson1_exercise4_setup.txt"),
                 start_cursor = {5, 0}, -- Start at the beginning
-                validation = { type = 'check_cursor_position', target_cursor = {5, 17} }, -- Target is the 'i' in 'quilt'
+                validation = { type = 'check_cursor_position', target_cursor = {5, 1} }, -- Target is the 'i' in 'Jinxed' (first 'i')
                 feedback = "You repeated the find backward!",
             },
         },
@@ -92,7 +92,7 @@ Let's practice searching. Type the search command and the pattern, press `<Enter
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module7_lesson2_exercise2_setup.txt"),
                 start_cursor = {7, 0}, -- Start at the end
-                validation = { type = 'check_cursor_position', target_cursor = {5, 4} }, -- Target is the start of "quick" on line 5
+                validation = { type = 'check_cursor_position', target_cursor = {5, 12} }, -- Target is the start of "quick" on line 5
                 feedback = "You found the word using backward search!",
             },
              {
@@ -100,7 +100,7 @@ Let's practice searching. Type the search command and the pattern, press `<Enter
                 type = "cursor_move",
                  setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module7_lesson2_exercise3_setup.txt"),
                  start_cursor = {5, 0}, -- Start on "Line 1"
-                 validation = { type = 'check_cursor_position', target_cursor = {7, 0} }, -- Target is the start of "Line 3"
+                 validation = { type = 'check_cursor_position', target_cursor = {6, 0} }, -- Target is the start of "Line 2"
                  feedback = "You repeated the search forward!",
              },
         },
@@ -126,7 +126,7 @@ Let's practice using counts with find and search. Use `:LearnVim exc` to check a
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module7_lesson3_exercise1_setup.txt"),
                 start_cursor = {5, 0}, -- Start at the beginning
-                validation = { type = 'check_cursor_position', target_cursor = {5, 20} }, -- Target is the 'i' in 'ivy' (1st in Jinxed, 2nd in wizards, 3rd in ivy)
+                validation = { type = 'check_cursor_position', target_cursor = {5, 21} }, -- Target is the 'i' in 'ivy' (1st in Jinxed, 2nd in wizards, 3rd in ivy)
                 feedback = "You jumped to the 3rd 'i'!",
             },
              {

--- a/lua/learn_vim/modules/module9.lua
+++ b/lua/learn_vim/modules/module9.lua
@@ -111,7 +111,7 @@ Let's practice using `%` in different languages. Use `:LearnVim exc` to check an
                 type = "cursor_move", -- Check cursor position
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module9_lesson3_exercise1_setup.txt"),
                 start_cursor = {5, 23}, -- Cursor on the first '{'
-                validation = { type = 'check_cursor_position', target_cursor = {10, 1} }, -- Target is the final '}'
+                validation = { type = 'check_cursor_position', target_cursor = {10, 0} }, -- Target is the final '}'
                 feedback = "You jumped to the matching curly brace!",
             },
              {
@@ -119,7 +119,7 @@ Let's practice using `%` in different languages. Use `:LearnVim exc` to check an
                 type = "cursor_move", -- Check cursor position
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module9_lesson3_exercise2_setup.txt"),
                 start_cursor = {5, 0}, -- Cursor on the first '('
-                validation = { type = 'check_cursor_position', target_cursor = {8, 27} }, -- Target is the final ')'
+                validation = { type = 'check_cursor_position', target_cursor = {8, 30} }, -- Target is the final ')'
                 feedback = "You jumped to the matching parenthesis!",
             },
              {
@@ -127,7 +127,7 @@ Let's practice using `%` in different languages. Use `:LearnVim exc` to check an
                 type = "cursor_move", -- Check cursor position
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module9_lesson3_exercise3_setup.txt"),
                 start_cursor = {8, 14}, -- Cursor on the '['
-                validation = { type = 'check_cursor_position', target_cursor = {8, 24} }, -- Target is the ']'
+                validation = { type = 'check_cursor_position', target_cursor = {8, 12} }, -- Target is the ']' of the '[]int' pair
                 feedback = "You jumped to the matching square bracket!",
             },
         },
@@ -221,7 +221,7 @@ Remember to use `:LearnVim exc` to check and `:LearnVim exr` to reset.
                 type = "cursor_move", -- Check cursor position
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module9_lesson5_exercise3_setup.txt"),
                 start_cursor = {6, 8}, -- Cursor on the '(' after print
-                validation = { type = 'check_cursor_position', target_cursor = {6, 22} }, -- Target is the closing ')'
+                validation = { type = 'check_cursor_position', target_cursor = {6, 23} }, -- Target is the closing ')'
                 feedback = "You jumped to the matching parenthesis in Dart!",
             },
              {
@@ -240,7 +240,7 @@ Remember to use `:LearnVim exc` to check and `:LearnVim exr` to reset.
                 type = "cursor_move", -- Check cursor position
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module9_lesson5_exercise5_setup.txt"),
                 start_cursor = {5, 10}, -- Cursor on the '{'
-                validation = { type = 'check_cursor_position', target_cursor = {7, 1} }, -- Target is the closing '}'
+                validation = { type = 'check_cursor_position', target_cursor = {7, 0} }, -- Target is the closing '}'
                 feedback = "You jumped to the matching curly brace in Rust!",
             },
              {
@@ -278,7 +278,7 @@ Remember to use `:LearnVim exc` to check and `:LearnVim exr` to reset.
                 type = "cursor_move", -- Check cursor position
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module9_lesson5_exercise9_setup.txt"),
                 start_cursor = {6, 14}, -- Cursor on the '{'
-                validation = { type = 'check_cursor_position', target_cursor = {9, 1} }, -- Target is the closing '}'
+                validation = { type = 'check_cursor_position', target_cursor = {9, 0} }, -- Target is the closing '}'
                 feedback = "You jumped to the matching curly brace in C++!",
             },
              {
@@ -297,7 +297,7 @@ Remember to use `:LearnVim exc` to check and `:LearnVim exr` to reset.
                 type = "cursor_move", -- Check cursor position
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module9_lesson5_exercise11_setup.txt"),
                 start_cursor = {6, 11}, -- Cursor on the '(' after println
-                validation = { type = 'check_cursor_position', target_cursor = {6, 27} }, -- Target is the closing ')'
+                validation = { type = 'check_cursor_position', target_cursor = {6, 28} }, -- Target is the closing ')'
                 feedback = "You jumped to the matching parenthesis in Kotlin!",
             },
              {


### PR DESCRIPTION
This commit addresses inaccuracies in `target_cursor` values and associated comments for exercises using `check_cursor_position` validation.

Affected modules and specific corrections:

- `lua/learn_vim/modules/module3.lua`:
  - lesson1, ex2: Corrected target for 'e' key on 'ivy'.
  - lesson3, ex4: Corrected target for '$' at end of line.
  - lesson4, ex3: Corrected target for '5w' word movement.
  - lesson4, ex4: Corrected start_cursor, target_cursor, and comment for '3b' word movement.

- `lua/learn_vim/modules/module7.lua`:
  - lesson1, ex1: Corrected target for `fa`.
  - lesson1, ex2: Corrected target for `tf`.
  - lesson1, ex3: Corrected target and comment for `fi;`.
  - lesson1, ex4: Corrected target and comment for `fi;,`.
  - lesson2, ex2: Corrected target for `?quick`.
  - lesson2, ex3: Corrected target and comment for `/Line then n`.
  - lesson3, ex1: Corrected target for `3fi`.

- `lua/learn_vim/modules/module9.lua`:
  - lesson3, ex1 (JS): Corrected target for `%` on function braces.
  - lesson3, ex2 (Racket): Corrected target for `%` on outer parentheses.
  - lesson3, ex3 (Go): Corrected target for `%` on `[]int` and updated comment.
  - lesson5, ex3 (Dart): Corrected target for `%` on print call parentheses.
  - lesson5, ex5 (Rust): Corrected target for `%` on main function braces.
  - lesson5, ex9 (C++): Corrected target for `%` on main function braces.
  - lesson5, ex11 (Kotlin): Corrected target for `%` on println call parentheses.

Modules 0, 1, 2 (implicitly), 4, 5, 6, 8, 10, 11, 12, 13, 14 were reviewed and found to have no errors of this specific type.