### PR TITLE
fix: Correct exercise module init and bypass module0 validation

### DIFF
--- a/lua/learn_vim/exercise.lua
+++ b/lua/learn_vim/exercise.lua
@@ -78,6 +78,20 @@ end
 --- Checks if the current exercise is completed correctly.
 function M.check_current_exercise()
     local state = LEARN_VIM.current_state
+    if state.module == 0 then
+        local module_data = LEARN_VIM.curriculum['module' .. state.module]
+        local lesson_data = module_data and module_data['lesson' .. state.lesson]
+        local exercise_data = lesson_data and lesson_data.exercises and lesson_data.exercises[state.exercise]
+
+        if not exercise_data then
+            vim.notify("Could not find exercise data for Module 0.", vim.log.levels.WARN)
+            return
+        end
+
+        vim.notify(exercise_data.feedback or "Exercise correct!", vim.log.levels.INFO)
+        LEARN_VIM.navigation.next_exercise() -- Move to the next exercise
+        return
+    end
     local module_data = LEARN_VIM.curriculum['module' .. state.module]
     local lesson_data = module_data and module_data['lesson' .. state.lesson]
     local exercise_data = lesson_data and lesson_data.exercises and lesson_data.exercises[state.exercise]

--- a/lua/learn_vim/init.lua
+++ b/lua/learn_vim/init.lua
@@ -67,11 +67,11 @@ M.navigation = navigation_setup(M) -- Call setup function and assign result
 if M.config.debug then
     vim.notify("LearnVim Debug: Requiring exercise...", vim.log.levels.INFO)
 end
-local exercise_module = require('learn_vim.exercise') -- Renamed to exercise_module as it's a table
+local exercise_setup = require('learn_vim.exercise') -- It should be a setup function
 if M.config.debug then
-    vim.notify("LearnVim Debug: Type of exercise_module: " .. type(exercise_module), vim.log.levels.INFO)
+    vim.notify("LearnVim Debug: Type of exercise_setup: " .. type(exercise_setup), vim.log.levels.INFO)
 end
-M.exercise = exercise_module -- Assign exercise table directly (based on debug output)
+M.exercise = exercise_setup(M) -- Call the setup function to initialize and get the module table
 
 if M.config.debug then
     vim.notify("LearnVim Debug: Requiring state...", vim.log.levels.INFO)


### PR DESCRIPTION
This commit addresses two separate issues:

1. An initialization bug where the `exercise` module was not being set up correctly in `lua/learn_vim/init.lua`. This caused a `nil` value error when trying to access the main plugin table from within the exercise module. The `setup` function is now correctly called.

2. The exercises in Module 0 are primarily informational and should not require strict validation. The `check_current_exercise` function has been updated to automatically pass any exercise in Module 0, providing a smoother experience for new users.