### PR TITLE
fix: Correct exercise validation, module loading, and navigation

### DIFF
--- a/lua/learn_vim/exercise.lua
+++ b/lua/learn_vim/exercise.lua
@@ -8,7 +8,7 @@ local LEARN_VIM = nil -- Placeholder for the main plugin module, set during setu
 
 -- --- Setup Function ---
 -- This function is called from init.lua to provide access to the main plugin module.
-function M.setup(learn_vim_module)
+local function setup(learn_vim_module)
     LEARN_VIM = learn_vim_module
     return M
 end
@@ -78,7 +78,7 @@ end
 --- Checks if the current exercise is completed correctly.
 function M.check_current_exercise()
     local state = LEARN_VIM.current_state
-    if state.module == 0 then
+    if state.module == 0 or state.module == 1 then
         local module_data = LEARN_VIM.curriculum['module' .. state.module]
         local lesson_data = module_data and module_data['lesson' .. state.lesson]
         local exercise_data = lesson_data and lesson_data.exercises and lesson_data.exercises[state.exercise]
@@ -89,7 +89,7 @@ function M.check_current_exercise()
         end
 
         vim.notify(exercise_data.feedback or "Exercise correct!", vim.log.levels.INFO)
-        LEARN_VIM.navigation.next_exercise() -- Move to the next exercise
+        LEARN_VIM.navigation.next_lesson() -- This function handles moving to the next exercise or lesson
         return
     end
     local module_data = LEARN_VIM.curriculum['module' .. state.module]
@@ -156,7 +156,7 @@ function M.check_current_exercise()
     -- Provide feedback and move to the next exercise if correct
     if is_correct then
         vim.notify(exercise_data.feedback or "Exercise correct!", vim.log.levels.INFO)
-        LEARN_VIM.navigation.next_exercise() -- Move to the next exercise
+        LEARN_VIM.navigation.next_lesson() -- This function handles moving to the next exercise or lesson
     else
         vim.notify("Exercise incorrect. Try again or use :LearnVim exr to reset.", vim.log.levels.WARN)
     end
@@ -202,4 +202,5 @@ end
 
 
 -- Return the module table M
-return M
+-- Return the setup function, which will then return the module table M
+return setup

--- a/lua/learn_vim/init.lua
+++ b/lua/learn_vim/init.lua
@@ -67,11 +67,11 @@ M.navigation = navigation_setup(M) -- Call setup function and assign result
 if M.config.debug then
     vim.notify("LearnVim Debug: Requiring exercise...", vim.log.levels.INFO)
 end
-local exercise_module = require('learn_vim.exercise') -- Renamed to exercise_module as it's a table
+local exercise_setup = require('learn_vim.exercise')
 if M.config.debug then
-    vim.notify("LearnVim Debug: Type of exercise_module: " .. type(exercise_module), vim.log.levels.INFO)
+    vim.notify("LearnVim Debug: Type of exercise_setup: " .. type(exercise_setup), vim.log.levels.INFO)
 end
-M.exercise = exercise_module -- Assign exercise table directly (based on debug output)
+M.exercise = exercise_setup(M) -- Call setup function and assign result
 
 if M.config.debug then
     vim.notify("LearnVim Debug: Requiring state...", vim.log.levels.INFO)

--- a/lua/learn_vim/modules/module3.lua
+++ b/lua/learn_vim/modules/module3.lua
@@ -28,24 +28,24 @@ Use `:LearnVim exc` to check when you think you've completed the task!
                 instruction = "Using only the `w` key, move the cursor to the start of the word 'wizards'. Then type `:LearnVim exc` to check.",
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson1_exercise1_setup.txt"),
-                start_cursor = {5, 0}, -- Start on 'J'
-                validation = { type = 'check_cursor_position', target_cursor = {5, 7} }, -- Target on 'w' of 'wizards'
+                start_cursor = {6, 1}, -- Start on 'J'
+                validation = { type = 'check_cursor_position', target_cursor = {6, 8} }, -- Target on 'w' of 'wizards'
                 feedback = "Correct! 'w' moves to the start of the next word.",
             },
             {
                 instruction = "Using only the `e` key, move the cursor to the end of the word 'ivy'. Then type `:LearnVim exc` to check.",
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson1_exercise2_setup.txt"),
-                start_cursor = {5, 15}, -- Start on 'p' of 'pluck'
-                validation = { type = 'check_cursor_position', target_cursor = {5, 23} }, -- Target on 'y' of 'ivy'
+                start_cursor = {6, 16}, -- Start on 'p' of 'pluck'
+                validation = { type = 'check_cursor_position', target_cursor = {6, 24} }, -- Target on 'y' of 'ivy'
                 feedback = "Correct! 'e' moves to the end of the word.",
             },
              {
                 instruction = "Using only the `b` key, move the cursor to the start of the word 'pluck'. Then type `:LearnVim exc` to check.",
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson1_exercise3_setup.txt"),
-                start_cursor = {5, 22}, -- Start on space after 'ivy'
-                validation = { type = 'check_cursor_position', target_cursor = {5, 15} }, -- Target on 'p' of 'pluck'
+                start_cursor = {6, 25}, -- Start on space after 'ivy'
+                validation = { type = 'check_cursor_position', target_cursor = {6, 16} }, -- Target on 'p' of 'pluck'
                 feedback = "Correct! 'b' moves to the start of the previous word.",
             },
         },
@@ -71,7 +71,7 @@ Let's practice jumping around this exercise buffer. Use `:LearnVim exc` to check
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson2_exercise1_setup.txt"),
                 start_cursor = {15, 5}, -- Start somewhere in the middle
-                validation = { type = 'check_cursor_position', target_cursor = {1, 0} }, -- Target is the first line (line 1, col 0)
+                validation = { type = 'check_cursor_position', target_cursor = {1, 1} }, -- Target is the first line (line 1, col 1)
                 feedback = "Great! You jumped to the top of the file.",
             },
             {
@@ -80,7 +80,7 @@ Let's practice jumping around this exercise buffer. Use `:LearnVim exc` to check
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson2_exercise2_setup.txt"),
                 start_cursor = {8, 10}, -- Start somewhere in the middle
                 -- Target is the last line (line 20)
-                validation = { type = 'check_cursor_position', target_cursor = {20, 0} },
+                validation = { type = 'check_cursor_position', target_cursor = {25, 1} },
                 feedback = "Excellent! You jumped to the bottom of the file.",
             },
         },
@@ -105,8 +105,8 @@ Let's practice these precise line movements. Use `:LearnVim exc` after each step
                 instruction = "Using `{number}G`, jump to line 10. Then type `:LearnVim exc` to check.",
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson3_exercise1_setup.txt"),
-                start_cursor = {5, 0}, -- Start on line 5
-                validation = { type = 'check_cursor_position', target_cursor = {10, 0} }, -- Target is line 10
+                start_cursor = {5, 1}, -- Start on line 5
+                validation = { type = 'check_cursor_position', target_cursor = {10, 1} }, -- Target is line 10
                 feedback = "You jumped to line 10!",
             },
              {
@@ -114,14 +114,14 @@ Let's practice these precise line movements. Use `:LearnVim exc` after each step
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson3_exercise2_setup.txt"),
                 start_cursor = {5, 10}, -- Start somewhere in the middle of the line
-                validation = { type = 'check_cursor_position', target_cursor = {5, 0} }, -- Target is column 0
+                validation = { type = 'check_cursor_position', target_cursor = {5, 1} }, -- Target is column 1
                 feedback = "Correct! '0' goes to the very first character.",
             },
              {
                 instruction = "Move the cursor to the first non-blank character using `^`. Then type `:LearnVim exc` to check.",
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson3_exercise3_setup.txt"),
-                start_cursor = {5, 0}, -- Start at the very beginning (column 0)
+                start_cursor = {5, 1}, -- Start at the very beginning (column 0)
                 validation = { type = 'check_cursor_position', target_cursor = {5, 4} }, -- Target is the first non-blank character ('T' at column 4)
                 feedback = "Correct! '^' skips leading whitespace.",
             },
@@ -129,7 +129,7 @@ Let's practice these precise line movements. Use `:LearnVim exc` after each step
                 instruction = "Move the cursor to the end of the line using `$`. Then type `:LearnVim exc` to check.",
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson3_exercise4_setup.txt"),
-                start_cursor = {5, 0}, -- Start at the beginning
+                start_cursor = {5, 1}, -- Start at the beginning
                 validation = { type = 'check_cursor_position', target_cursor = {5, 15} }, -- Target is the last character (the '.')
                 feedback = "Correct! '$' goes to the end of the line.",
             },
@@ -157,16 +157,16 @@ Let's practice using counts with vertical and horizontal movements. Use `:LearnV
                 instruction = "Using a numerical prefix with `j`, move down exactly 3 lines from the starting position. Then type `:LearnVim exc` to check.",
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson4_exercise1_setup.txt"),
-                start_cursor = {5, 0}, -- Start on "Start here."
-                validation = { type = 'check_cursor_position', target_cursor = {8, 0} }, -- Target is "Target line." (3 lines down)
+                start_cursor = {5, 1}, -- Start on "Start here."
+                validation = { type = 'check_cursor_position', target_cursor = {8, 1} }, -- Target is "Target line." (3 lines down)
                 feedback = "Excellent! You moved down multiple lines with a count.",
             },
             {
                 instruction = "Using a numerical prefix with `k`, move up exactly 4 lines from the starting position. Then type `:LearnVim exc` to check.",
                 type = "cursor_move",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module3_lesson4_exercise2_setup.txt"),
-                start_cursor = {10, 0}, -- Start on "Start here."
-                validation = { type = 'check_cursor_position', target_cursor = {6, 0} }, -- Target is "Target line." (4 lines up)
+                start_cursor = {10, 1}, -- Start on "Start here."
+                validation = { type = 'check_cursor_position', target_cursor = {6, 1} }, -- Target is "Target line." (4 lines up)
                 feedback = "Well done! You moved up multiple lines with a count.",
             },
             {


### PR DESCRIPTION
This commit includes a series of fixes to the LearnVim plugin to resolve multiple reported issues:

1.  **Module 0 & 1 Bypass**: Exercises in Module 0 and 1 are now automatically passed when checked. This is because they are primarily informational.

2.  **Module Initialization Refactor**: The `exercise` module has been refactored to export a setup function, making its initialization pattern consistent with other modules and fixing a crash related to a `nil` value.

3.  **Module 3 Coordinate Fix**: The `start_cursor` and `target_cursor` coordinates for all exercises in Module 3 were corrected. The previous coordinates were incorrect due to off-by-one errors and the use of invalid 0-based column indexing.

4.  **Navigation Function Call Fix**: Corrected the function call to advance to the next exercise. The code now calls `navigation.next_lesson()`, which correctly handles advancing both exercises and lessons, fixing a crash upon exercise completion.