### PR TITLE
fix: Correct exercise validation, module loading, and navigation

### DIFF
--- a/lua/learn_vim/exercise.lua
+++ b/lua/learn_vim/exercise.lua
@@ -78,7 +78,7 @@ end
 --- Checks if the current exercise is completed correctly.
 function M.check_current_exercise()
     local state = LEARN_VIM.current_state
-    if state.module == 0 or state.module == 1 then
+    if state.module == 0 then
         local module_data = LEARN_VIM.curriculum['module' .. state.module]
         local lesson_data = module_data and module_data['lesson' .. state.lesson]
         local exercise_data = lesson_data and lesson_data.exercises and lesson_data.exercises[state.exercise]


### PR DESCRIPTION
This commit includes a series of fixes to the LearnVim plugin to resolve multiple reported issues:

1.  **Module 0 Bypass**: Exercises in Module 0 are now automatically passed when checked, as they are primarily informational.

2.  **Module Initialization Refactor**: The `exercise` module has been refactored to export a setup function, making its initialization pattern consistent with other modules and fixing a crash related to a `nil` value.

3.  **Module 3 Coordinate Fix**: The `start_cursor` and `target_cursor` coordinates for all exercises in Module 3 were corrected. The previous coordinates were incorrect due to off-by-one errors and the use of invalid 0-based column indexing.

4.  **Navigation Function Call Fix**: Corrected the function call to advance to the next exercise. The code now calls `navigation.next_lesson()`, which correctly handles advancing both exercises and lessons, fixing a crash upon exercise completion.