### PR TITLE
Fix(exercise): Correct validation logic and improve instructions

### DIFF
--- a/lua/learn_vim/exercise.lua
+++ b/lua/learn_vim/exercise.lua
@@ -111,8 +111,28 @@ function M.check_current_exercise()
 
     -- Perform validation based on type
     if validation.type == 'check_buffer_content' then
-        local target_content = table.concat(vim.split(validation.target_content, '\n'), '\n')
-        is_correct = (current_buffer_content == target_content)
+        local current_lines = vim.api.nvim_buf_get_lines(exercise_bufnr, 0, -1, false)
+        -- Handle nil target_content gracefully
+        local target_content = validation.target_content or ""
+        local target_lines = vim.split(target_content, '\n')
+
+        -- If target file ends with a newline, vim.split creates an extra empty string.
+        -- We remove it to match the behavior of nvim_buf_get_lines.
+        if #target_lines > 0 and target_lines[#target_lines] == "" then
+            table.remove(target_lines)
+        end
+
+        if #current_lines ~= #target_lines then
+            is_correct = false
+        else
+            is_correct = true
+            for i = 1, #current_lines do
+                if current_lines[i] ~= target_lines[i] then
+                    is_correct = false
+                    break
+                end
+            end
+        end
 
     -- New validation type: check_buffer_content_regex
     elseif validation.type == 'check_buffer_content_regex' then

--- a/lua/learn_vim/modules/module5.lua
+++ b/lua/learn_vim/modules/module5.lua
@@ -137,11 +137,12 @@ Good luck!
 ]],
         exercises = {
             {
-                instruction = "Edit the paragraph to match the target content. Hint: Use `dw`, `dd`, `p`, and `.`",
+                instruction = [[Edit the paragraph to match the target content below. Hint: Use `dw`, `dd`, `p`, and `.`
+
+TARGET:
+It was the best of times.]],
                 type = "insert_text",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise1_setup.txt"),
-                -- Target: Remove all phrases starting with "it was the" except the first one, and keep only "best of times".
-                -- This requires deleting words and lines.
                 validation = {
                     type = 'check_buffer_content',
                     target_content = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise1_target.txt")
@@ -149,10 +150,12 @@ Good luck!
                 feedback = "Test 1 completed! You practiced deleting and potentially repeating.",
             },
              {
-                instruction = "Edit the paragraph to match the target content. Hint: Use `cw`, `cc`, `r`, and `<Esc>`.",
+                instruction = [[Edit the paragraph to match the target content below. Hint: Use `cw`, `cc`, `r`, and `<Esc>`.
+
+TARGET:
+Call me Ahab. Some years ago—never mind how long precisely—having little or no gold in my purse, and nothing particular to interest me on shore, I thought I would travel about a little and see the watery part of the world!]],
                 type = "insert_text",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise2_setup.txt"),
-                -- Target: Change "Ishmael" to "Ahab", "money" to "gold", "sail" to "travel", and replace the '.' after "world" with '!'.
                 validation = {
                     type = 'check_buffer_content',
                     target_content = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise2_target.txt")
@@ -160,10 +163,16 @@ Good luck!
                 feedback = "Test 2 completed! You practiced changing and replacing.",
             },
              {
-                instruction = "Edit the paragraph to match the target content. Hint: Use `yy`, `p`, `dd`, and navigation commands.",
+                instruction = [[Reorder the lines to match the target order below. Hint: Use `yy`, `p`, `dd`, and navigation commands.
+
+TARGET:
+Line D.
+Line B.
+Line E.
+Line A.
+Line C.]],
                 type = "insert_text",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise3_setup.txt"),
-                -- Target: Reorder the lines to be D, B, E, A, C
                 validation = {
                     type = 'check_buffer_content',
                     target_content = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise3_target.txt")
@@ -171,10 +180,12 @@ Good luck!
                 feedback = "Test 3 completed! You practiced moving lines.",
             },
              {
-                instruction = "Edit the paragraph to match the target content. Hint: Combine navigation and actions. Use `u` and `<C-r>` if you make mistakes.",
+                instruction = [[Edit the paragraph to match the target content below. Hint: Combine navigation and actions. Use `u` and `<C-r>` if you make mistakes.
+
+TARGET:
+It is a truth universally acknowledged, that a wealthy person in possession of a good fortune, must be in want of a partner.]],
                 type = "insert_text",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise4_setup.txt"),
-                -- Target: Delete the second paragraph entirely. Change "single man" to "wealthy person". Replace "wife" with "partner".
                 validation = {
                     type = 'check_buffer_content',
                     target_content = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise4_target.txt")
@@ -182,10 +193,12 @@ Good luck!
                 feedback = "Test 4 completed! You applied a range of commands.",
             },
             { -- New Exercise 5.4.5
-                instruction = "Edit the paragraph to match the target content. Hint: Use a variety of commands from Modules 3-5.",
+                instruction = [[Edit the paragraph to match the target content below. Hint: Use a variety of commands from Modules 3-5.
+
+TARGET:
+All that is silver does not glitter, Not all those who roam are lost; The ancient that is strong does not wither, Deep roots are not reached by the sun. From the ashes a spark shall be woken, A glow from the shadows shall spring; Renewed shall be blade that was mended, The crownless again shall be queen.]],
                 type = "insert_text",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise5_setup.txt"),
-                -- Target: Change "gold" to "silver", "wander" to "roam", "old" to "ancient", "frost" to "sun", "fire" to "spark", "light" to "glow", "broken" to "mended", "king" to "queen".
                 validation = {
                     type = 'check_buffer_content',
                     target_content = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise5_target.txt")


### PR DESCRIPTION
This commit addresses two issues in the LearnVim exercises:

1. The buffer content validation for exercises was failing due to inconsistencies in handling trailing newlines. The `check_buffer_content` function in `exercise.lua` now performs a more robust line-by-line comparison instead of a simple string comparison. This ensures that trailing newlines in target files do not cause validation to fail incorrectly.

2. The instructions for the mid-term test exercises in Module 5, Lesson 4 were incomplete. They instructed the user to match a target text without displaying what that target was. The instruction strings for these exercises in `module5.lua` have been updated to include the explicit target text, making the exercises clear and solvable.