### PR TITLE
Fix(exercise): Finalize validation logic and Module 5 instructions

### DIFF
--- a/lua/learn_vim/exercise.lua
+++ b/lua/learn_vim/exercise.lua
@@ -112,13 +112,14 @@ function M.check_current_exercise()
     -- Perform validation based on type
     if validation.type == 'check_buffer_content' then
         local current_lines = vim.api.nvim_buf_get_lines(exercise_bufnr, 0, -1, false)
-        -- Handle nil target_content gracefully
         local target_content = validation.target_content or ""
         local target_lines = vim.split(target_content, '\n')
 
-        -- If target file ends with a newline, vim.split creates an extra empty string.
-        -- We remove it to match the behavior of nvim_buf_get_lines.
-        if #target_lines > 0 and target_lines[#target_lines] == "" then
+        -- Trim any trailing empty lines from both the buffer and the target
+        while #current_lines > 0 and current_lines[#current_lines] == "" do
+            table.remove(current_lines)
+        end
+        while #target_lines > 0 and target_lines[#target_lines] == "" do
             table.remove(target_lines)
         end
 

--- a/lua/learn_vim/exercise_content/module5_lesson4_exercise1_setup.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson4_exercise1_setup.txt
@@ -2,4 +2,6 @@
 " Instruction: Edit the paragraph to match the target content. Hint: Use `dw`, `dd`, `p`, and `.`
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
+TARGET TEXT: It was the best of times.
+
 It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity, it was the season of Light, it was the season of Darkness, it was the spring of hope, it was the winter of despair.]

--- a/lua/learn_vim/exercise_content/module5_lesson4_exercise1_target.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson4_exercise1_target.txt
@@ -2,4 +2,6 @@
 " Instruction: Edit the paragraph to match the target content. Hint: Use `dw`, `dd`, `p`, and `.`
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
+TARGET TEXT: It was the best of times.
+
 It was the best of times.

--- a/lua/learn_vim/exercise_content/module5_lesson4_exercise2_setup.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson4_exercise2_setup.txt
@@ -2,4 +2,6 @@
 " Instruction: Edit the paragraph to match the target content. Hint: Use `cw`, `cc`, `r`, and `<Esc>`.
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
+TARGET TEXT: Call me Ahab. Some years ago—never mind how long precisely—having little or no gold in my purse, and nothing particular to interest me on shore, I thought I would travel about a little and see the watery part of the world!
+
 Call me Ishmael. Some years ago—never mind how long precisely—having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world.]

--- a/lua/learn_vim/exercise_content/module5_lesson4_exercise2_target.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson4_exercise2_target.txt
@@ -2,4 +2,6 @@
 " Instruction: Edit the paragraph to match the target content. Hint: Use `cw`, `cc`, `r`, and `<Esc>`.
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
+TARGET TEXT: Call me Ahab. Some years ago—never mind how long precisely—having little or no gold in my purse, and nothing particular to interest me on shore, I thought I would travel about a little and see the watery part of the world!
+
 Call me Ahab. Some years ago—never mind how long precisely—having little or no gold in my purse, and nothing particular to interest me on shore, I thought I would travel about a little and see the watery part of the world!

--- a/lua/learn_vim/exercise_content/module5_lesson4_exercise3_setup.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson4_exercise3_setup.txt
@@ -2,6 +2,12 @@
 " Instruction: Edit the paragraph to match the target content. Hint: Use `yy`, `p`, `dd`, and navigation commands.
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
+TARGET TEXT:
+Line D.
+Line B.
+Line E.
+Line A.
+Line C.
 
 Line A.
 Line B.

--- a/lua/learn_vim/exercise_content/module5_lesson4_exercise3_target.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson4_exercise3_target.txt
@@ -2,6 +2,12 @@
 " Instruction: Edit the paragraph to match the target content. Hint: Use `yy`, `p`, `dd`, and navigation commands.
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
+TARGET TEXT:
+Line D.
+Line B.
+Line E.
+Line A.
+Line C.
 
 Line D.
 Line B.

--- a/lua/learn_vim/exercise_content/module5_lesson4_exercise4_setup.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson4_exercise4_setup.txt
@@ -2,5 +2,7 @@
 " Instruction: Edit the paragraph to match the target content. Hint: Combine navigation and actions. Use `u` and `<C-r>` if you make mistakes.
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
+TARGET TEXT: It is a truth universally acknowledged, that a wealthy person in possession of a good fortune, must be in want of a partner.
+
 It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.
 However little known the feelings or views of such a man may be on his first entering a neighbourhood, this truth is so well fixed in the minds of the surrounding families, that he is considered the rightful property of some one or other of their daughters.]

--- a/lua/learn_vim/exercise_content/module5_lesson4_exercise4_target.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson4_exercise4_target.txt
@@ -2,4 +2,6 @@
 " Instruction: Edit the paragraph to match the target content. Hint: Combine navigation and actions. Use `u` and `<C-r>` if you make mistakes.
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
+TARGET TEXT: It is a truth universally acknowledged, that a wealthy person in possession of a good fortune, must be in want of a partner.
+
 It is a truth universally acknowledged, that a wealthy person in possession of a good fortune, must be in want of a partner.

--- a/lua/learn_vim/exercise_content/module5_lesson4_exercise5_setup.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson4_exercise5_setup.txt
@@ -2,4 +2,6 @@
 " Instruction: Edit the paragraph to match the target content. Hint: Use a variety of commands from Modules 3-5.
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
+TARGET TEXT: All that is silver does not glitter, Not all those who roam are lost; The ancient that is strong does not wither, Deep roots are not reached by the sun. From the ashes a spark shall be woken, A glow from the shadows shall spring; Renewed shall be blade that was mended, The crownless again shall be queen.
+
 All that is gold does not glitter, Not all those who wander are lost; The old that is strong does not wither, Deep roots are not reached by the frost. From the ashes a fire shall be woken, A light from the shadows shall spring; Renewed shall be blade that was broken, The crownless again shall be king.]

--- a/lua/learn_vim/exercise_content/module5_lesson4_exercise5_target.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson4_exercise5_target.txt
@@ -2,4 +2,6 @@
 " Instruction: Edit the paragraph to match the target content. Hint: Use a variety of commands from Modules 3-5.
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
+TARGET TEXT: All that is silver does not glitter, Not all those who roam are lost; The ancient that is strong does not wither, Deep roots are not reached by the sun. From the ashes a spark shall be woken, A glow from the shadows shall spring; Renewed shall be blade that was mended, The crownless again shall be queen.
+
 All that is silver does not glitter, Not all those who roam are lost; The ancient that is strong does not wither, Deep roots are not reached by the sun. From the ashes a spark shall be woken, A glow from the shadows shall spring; Renewed shall be blade that was mended, The crownless again shall be queen.

--- a/lua/learn_vim/modules/module5.lua
+++ b/lua/learn_vim/modules/module5.lua
@@ -137,12 +137,11 @@ Good luck!
 ]],
         exercises = {
             {
-                instruction = [[Edit the paragraph to match the target content below. Hint: Use `dw`, `dd`, `p`, and `.`
-
-TARGET:
-It was the best of times.]],
+                instruction = "Edit the paragraph to match the target content. Hint: Use `dw`, `dd`, `p`, and `.`",
                 type = "insert_text",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise1_setup.txt"),
+                -- Target: Remove all phrases starting with "it was the" except the first one, and keep only "best of times".
+                -- This requires deleting words and lines.
                 validation = {
                     type = 'check_buffer_content',
                     target_content = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise1_target.txt")
@@ -150,12 +149,10 @@ It was the best of times.]],
                 feedback = "Test 1 completed! You practiced deleting and potentially repeating.",
             },
              {
-                instruction = [[Edit the paragraph to match the target content below. Hint: Use `cw`, `cc`, `r`, and `<Esc>`.
-
-TARGET:
-Call me Ahab. Some years ago—never mind how long precisely—having little or no gold in my purse, and nothing particular to interest me on shore, I thought I would travel about a little and see the watery part of the world!]],
+                instruction = "Edit the paragraph to match the target content. Hint: Use `cw`, `cc`, `r`, and `<Esc>`.",
                 type = "insert_text",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise2_setup.txt"),
+                -- Target: Change "Ishmael" to "Ahab", "money" to "gold", "sail" to "travel", and replace the '.' after "world" with '!'.
                 validation = {
                     type = 'check_buffer_content',
                     target_content = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise2_target.txt")
@@ -163,16 +160,10 @@ Call me Ahab. Some years ago—never mind how long precisely—having little or 
                 feedback = "Test 2 completed! You practiced changing and replacing.",
             },
              {
-                instruction = [[Reorder the lines to match the target order below. Hint: Use `yy`, `p`, `dd`, and navigation commands.
-
-TARGET:
-Line D.
-Line B.
-Line E.
-Line A.
-Line C.]],
+                instruction = "Edit the paragraph to match the target content. Hint: Use `yy`, `p`, `dd`, and navigation commands.",
                 type = "insert_text",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise3_setup.txt"),
+                -- Target: Reorder the lines to be D, B, E, A, C
                 validation = {
                     type = 'check_buffer_content',
                     target_content = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise3_target.txt")
@@ -180,12 +171,10 @@ Line C.]],
                 feedback = "Test 3 completed! You practiced moving lines.",
             },
              {
-                instruction = [[Edit the paragraph to match the target content below. Hint: Combine navigation and actions. Use `u` and `<C-r>` if you make mistakes.
-
-TARGET:
-It is a truth universally acknowledged, that a wealthy person in possession of a good fortune, must be in want of a partner.]],
+                instruction = "Edit the paragraph to match the target content. Hint: Combine navigation and actions. Use `u` and `<C-r>` if you make mistakes.",
                 type = "insert_text",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise4_setup.txt"),
+                -- Target: Delete the second paragraph entirely. Change "single man" to "wealthy person". Replace "wife" with "partner".
                 validation = {
                     type = 'check_buffer_content',
                     target_content = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise4_target.txt")
@@ -193,12 +182,10 @@ It is a truth universally acknowledged, that a wealthy person in possession of a
                 feedback = "Test 4 completed! You applied a range of commands.",
             },
             { -- New Exercise 5.4.5
-                instruction = [[Edit the paragraph to match the target content below. Hint: Use a variety of commands from Modules 3-5.
-
-TARGET:
-All that is silver does not glitter, Not all those who roam are lost; The ancient that is strong does not wither, Deep roots are not reached by the sun. From the ashes a spark shall be woken, A glow from the shadows shall spring; Renewed shall be blade that was mended, The crownless again shall be queen.]],
+                instruction = "Edit the paragraph to match the target content. Hint: Use a variety of commands from Modules 3-5.",
                 type = "insert_text",
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise5_setup.txt"),
+                -- Target: Change "gold" to "silver", "wander" to "roam", "old" to "ancient", "frost" to "sun", "fire" to "spark", "light" to "glow", "broken" to "mended", "king" to "queen".
                 validation = {
                     type = 'check_buffer_content',
                     target_content = Utils.read_file_content("lua/learn_vim/exercise_content/module5_lesson4_exercise5_target.txt")


### PR DESCRIPTION
This commit contains the final set of changes based on user feedback, including:

1.  A robust `check_buffer_content` validation logic in `lua/learn_vim/exercise.lua` that trims all trailing empty lines from both the buffer and target content before comparison. This definitively solves issues with extraneous newlines causing check failures.

2.  Updated exercise files for Lesson 5.4 (the Mid-Term Test) to include an explicit `TARGET TEXT:` section at the top of both the setup and target files. This makes the exercise goals clear to the user.

3.  Reverted unintended changes to Lesson 5.3, scoping the new format change only to Lesson 5.4 as requested by the user.