### PR TITLE
Fix cursor coordinates logic

### DIFF
--- a/lua/learn_vim/exercise.lua
+++ b/lua/learn_vim/exercise.lua
@@ -144,8 +144,8 @@ function M.check_current_exercise()
 
     elseif validation.type == 'check_cursor_position' then
         local current_cursor = vim.api.nvim_win_get_cursor(state.exercise_winid)
-         -- Adjusting from 0-indexed Nvim to 1-indexed Lua for comparison with target
-        local current_line = current_cursor[1] + 1
+         -- Adjusting for row being 1-indexed, and column being 0-indexed
+        local current_line = current_cursor[1]
         local current_col = current_cursor[2] + 1
         local target_cursor = validation.target_cursor
         is_correct = (current_line == target_cursor[1] and current_col == target_cursor[2])

--- a/lua/learn_vim/exercise.lua
+++ b/lua/learn_vim/exercise.lua
@@ -55,10 +55,10 @@ function M.load_current_exercise()
 
     -- Set cursor position if specified
     if exercise_data.start_cursor then
-        -- Nvim cursor is 0-indexed for line, 0-indexed for column
+        -- Nvim cursor is 1-indexed for line, 0-indexed for column
         -- Lua table is 1-indexed for line, 1-indexed for column
         -- Adjusting from 1-indexed Lua to 0-indexed Nvim
-        local line = exercise_data.start_cursor[1] - 1
+        local line = exercise_data.start_cursor[1]
         local col = exercise_data.start_cursor[2] - 1
         vim.api.nvim_win_set_cursor(state.exercise_winid, {line, col})
     else

--- a/lua/learn_vim/modules/module2.lua
+++ b/lua/learn_vim/modules/module2.lua
@@ -25,8 +25,8 @@ Try moving the cursor left and right in the exercise pane. Remember to type `:Le
                 instruction = "Using only the `l` key, move the cursor to the character 'D'. Type `:LearnVim exc` to check.", -- Updated instruction
                 type = "cursor_move", -- Indicates exercise is about cursor position
                 setup_text = Utils.read_file_content("lua/learn_vim/exercise_content/module2_lesson1_exercise1_setup.txt"),
-                start_cursor = {5, 0}, -- Cursor starts on 'A' (line 5, column 0)
-                validation = { type = 'check_cursor_position', target_cursor = {6, 3} }, -- Target cursor is on 'D' (line 5, column 3)
+                start_cursor = {6, 0}, -- Cursor starts on 'A' (line 6, column 0)
+                validation = { type = 'check_cursor_position', target_cursor = {6, 4} }, -- Target cursor is on 'D' (line 6, column 4)
                 feedback = "Correct! You moved right.",
             },
              {

--- a/lua/learn_vim/ui.lua
+++ b/lua/learn_vim/ui.lua
@@ -367,7 +367,7 @@ return function(M) -- Accept the parent module M as an argument
             j = { char = 'j', line = 7, col_start = 5, col_end = 6, hl_group = 'LearnVimJKey' }
         }
 
-        -- Apply initial highlights (0-indexed lines, 0-indexed byte-based columns)
+        -- Apply initial highlights (1-indexed lines, 0-indexed byte-based columns)
         for _, key_info in pairs(motion_keys_info) do
             vim.api.nvim_buf_add_highlight(menu_bufnr, ns_id, key_info.hl_group, key_info.line, key_info.col_start, key_info.col_end)
         end


### PR DESCRIPTION
At it's root, the problem here seems to be a misunderstanding of what `nvim_win_set_cursor` and related functions expect; nvim uses a [(1,0)-indexed cursor position](https://neovim.io/doc/user/api.html#api-indexing:~:text=the%20following%20API%20functions%20use%20%22mark%2Dlike%22%20indexing%20(1%2Dbased%20lines%2C%200%2Dbased%20columns)) but the current code expects [(0,0)-indexed positions](https://github.com/melkyr/learn-vim/blob/5d336ac6a63aac1ad14ddb450443f8573d15b391/lua/learn_vim/exercise.lua#L58). 

This causes all the line placement/checks to be off by one. This MR addresses the discrepancy but it might be better to directly adopt nvim's coord expectations to eliminate the need for any conversion.

All uses of `start_cursor` and `check_cursor_position` are going to need updating assuming this fix is correct - I can whiz through the code base making those changes, but at the time of writing I've only updated exercise 2.1.1 to demonstrate/validate the changes made.

I didn't look into why `display_motion_practice_menu` seems to render correctly, only correcting the comment.

closes https://github.com/melkyr/learn-vim/issues/28 