### PR TITLE
Fixups for module 5

### DIFF
--- a/lua/learn_vim/exercise_content/module5_lesson1_exercise1_target.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson1_exercise1_target.txt
@@ -3,6 +3,6 @@
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
 
-Please  this word.
-Also  this word.
-And  this word too.
+Please this word.
+Also this word.
+And this word too.

--- a/lua/learn_vim/exercise_content/module5_lesson3_exercise1_setup.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson3_exercise1_setup.txt
@@ -2,4 +2,6 @@
 " Instruction: Edit the paragraph to match the target content. Apply commands learned in Modules 3-5.
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
+TARGET TEXT: The agile fox cat. This is a simple sentence for practicing editing commands. We will delete some words, change others, and maybe move a few things around. Undo and repeat can be helpful here.
+
 The quick brown fox jumps over the lazy dog. This is a simple sentence for practicing editing commands. We will delete some words, change others, and maybe move a few things around. Undo and repeat can be helpful here.

--- a/lua/learn_vim/exercise_content/module5_lesson3_exercise1_target.txt
+++ b/lua/learn_vim/exercise_content/module5_lesson3_exercise1_target.txt
@@ -2,4 +2,6 @@
 " Instruction: Edit the paragraph to match the target content. Apply commands learned in Modules 3-5.
 " Use `:LearnVim exc` to check, `:LearnVim exr` to reset.
 " ---------------------------------------------
-The agile fox  cat. This is a simple sentence for practicing editing commands. We will delete some words, change others, and maybe move a few things around. Undo and repeat can be helpful here.
+TARGET TEXT: The agile fox cat. This is a simple sentence for practicing editing commands. We will delete some words, change others, and maybe move a few things around. Undo and repeat can be helpful here.
+
+The agile fox cat. This is a simple sentence for practicing editing commands. We will delete some words, change others, and maybe move a few things around. Undo and repeat can be helpful here.


### PR DESCRIPTION
`dw` deletes the trailing whitespace, which is incorrectly in the expectations.

For lesson 3, if the target text isn't present users don't know what they are supposed to do without reading the plugin source files.